### PR TITLE
Refactor directed.py to use d3json module

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ to the user who mentions or retweets them:
     % utils/directed.py --mode mentions nasa-20130306102105.json > nasa-directed-mentions.html
     % utils/directed.py --mode retweets nasa-20130306102105.json > nasa-directed-retweets.html
     % utils/directed.py --mode replies nasa-20130306102105.json > nasa-directed-replies.html
+    
+(Use "--output json" to output the nodes/links data for use with other D3 examples, or "--help" for 
+other options.)
 
 Or if you want to output [GeoJSON](http://geojson.org/) from tweets where geo coordinates are available:
 

--- a/utils/d3json.py
+++ b/utils/d3json.py
@@ -6,55 +6,55 @@ import json
 
 def nodeslinks(threshold):
 
-	nodes = []
-	links = []
-	
-	# lines look like "nodeA,nodeB,123"
-	for line in sys.stdin:
-		tokens = line.split(",")
-		# use try to ignore header line
-		try:
-			if int(tokens[2]) >= threshold:
-				if not tokens[0] in nodes:
-					nodes.append(tokens[0])
-				if not tokens[1] in nodes:
-					nodes.append(tokens[1])
-				links.append({"source": nodes.index(tokens[0]), 
-				"target": nodes.index(tokens[1]), 
-				"value": int(tokens[2])}) 
-		except:
-			continue
-	
-	nodelist = []
-	for node in nodes:
-		nodelist.append({"name": node})
-	
-	print json.dump({"nodes": nodelist, "links": links})
+    nodes = []
+    links = []
+    
+    # lines look like "nodeA,nodeB,123"
+    for line in sys.stdin:
+        tokens = line.split(",")
+        # use try to ignore header line
+        try:
+            if int(tokens[2]) >= threshold:
+                if not tokens[0] in nodes:
+                    nodes.append(tokens[0])
+                if not tokens[1] in nodes:
+                    nodes.append(tokens[1])
+                links.append({"source": nodes.index(tokens[0]), 
+                "target": nodes.index(tokens[1]), 
+                "value": int(tokens[2])}) 
+        except:
+            continue
+    
+    nodelist = []
+    for node in nodes:
+        nodelist.append({"name": node})
+    
+    print json.dump({"nodes": nodelist, "links": links})
 
 def nodeslinktrees(nodes, links, opts, args):
-	# generate nodes json
-	nodesoutput = []
-	usernames = []
-	for u in nodes.iterkeys():
-		node = nodes[u]
-		usernames.append(u)
-		nodesoutput.append({"name": u, 
-			"title": str(u + " (" + str(node["source"]) + "/" + str(node["target"]) + ")")})
-	   
-	# generate links json
-	linksoutput = []
-	for source in links.iterkeys():
-		for target in links[source].iterkeys():
-			value = links[source][target]
-			if value >= opts["threshold"]:
-				linksoutput.append({"source": usernames.index(target), 
-					"target": usernames.index(source), 
-					"value": value})
+    # generate nodes json
+    nodesoutput = []
+    usernames = []
+    for u in nodes.iterkeys():
+        node = nodes[u]
+        usernames.append(u)
+        nodesoutput.append({"name": u, 
+            "title": str(u + " (" + str(node["source"]) + "/" + str(node["target"]) + ")")})
+       
+    # generate links json
+    linksoutput = []
+    for source in links.iterkeys():
+        for target in links[source].iterkeys():
+            value = links[source][target]
+            if value >= opts["threshold"]:
+                linksoutput.append({"source": usernames.index(target), 
+                    "target": usernames.index(source), 
+                    "value": value})
 
-	return {"nodes": nodesoutput, "links": linksoutput, "opts": opts, "args": args}
+    return {"nodes": nodesoutput, "links": linksoutput, "opts": opts, "args": args}
 
 def embed(template, d3json):
-	# generate html by replacing token
-	template_file = os.path.join(os.path.dirname(__file__), "templates", template)
-	with open (template_file, "r") as template:
-		print template.read().replace('$JSON$', json.dumps(d3json))
+    # generate html by replacing token
+    template_file = os.path.join(os.path.dirname(__file__), "templates", template)
+    with open (template_file, "r") as template:
+        print template.read().replace('$JSON$', json.dumps(d3json))

--- a/utils/d3json.py
+++ b/utils/d3json.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import json
+
+def nodeslinks(threshold):
+
+	nodes = []
+	links = []
+	
+	# lines look like "nodeA,nodeB,123"
+	for line in sys.stdin:
+		tokens = line.split(",")
+		# use try to ignore header line
+		try:
+			if int(tokens[2]) >= threshold:
+				if not tokens[0] in nodes:
+					nodes.append(tokens[0])
+				if not tokens[1] in nodes:
+					nodes.append(tokens[1])
+				links.append({"source": nodes.index(tokens[0]), 
+				"target": nodes.index(tokens[1]), 
+				"value": int(tokens[2])}) 
+		except:
+			continue
+	
+	nodelist = []
+	for node in nodes:
+		nodelist.append({"name": node})
+	
+	print json.dump({"nodes": nodelist, "links": links})
+
+def nodeslinktrees(nodes, links, opts, args):
+	# generate nodes json
+	nodesoutput = []
+	usernames = []
+	for u in nodes.iterkeys():
+		node = nodes[u]
+		usernames.append(u)
+		nodesoutput.append({"name": u, 
+			"title": str(u + " (" + str(node["source"]) + "/" + str(node["target"]) + ")")})
+	   
+	# generate links json
+	linksoutput = []
+	for source in links.iterkeys():
+		for target in links[source].iterkeys():
+			value = links[source][target]
+			if value >= opts["threshold"]:
+				linksoutput.append({"source": usernames.index(target), 
+					"target": usernames.index(source), 
+					"value": value})
+
+	return {"nodes": nodesoutput, "links": linksoutput, "opts": opts, "args": args}
+
+def embed(template, d3json):
+	# generate html by replacing token
+	template_file = os.path.join(os.path.dirname(__file__), "templates", template)
+	with open (template_file, "r") as template:
+		print template.read().replace('$JSON$', json.dumps(d3json))

--- a/utils/directed.py
+++ b/utils/directed.py
@@ -14,12 +14,12 @@ opt_parser = optparse.OptionParser()
 opt_parser.add_option("-m", "--mode", dest="mode", help="retweets (default) | mentions | replies",
     default='retweets')
 opt_parser.add_option("-t", "--threshold", dest="threshold", type="int", 
-	help="minimum links to qualify for inclusion (default: 1)", default=1)
+    help="minimum links to qualify for inclusion (default: 1)", default=1)
 opt_parser.add_option("-o", "--output", dest="output", type="str", 
-	help="embed | json (default: embed)", default="embed")
+    help="embed | json (default: embed)", default="embed")
 opt_parser.add_option("-p", "--template", dest="template", type="str", 
-	help="name of template in utils/template (default: directed.html)", default="directed.html")
-	
+    help="name of template in utils/template (default: directed.html)", default="directed.html")
+    
 opts, args = opt_parser.parse_args()
 
 # prepare to serialize opts and args as json
@@ -35,54 +35,54 @@ nodes = {}
 
 def addlink(source, target):
     if not source in links:
-    	links[source] = {}
+        links[source] = {}
     if not source in nodes:
-    	nodes[source] = {"source": 0, "target": 1}
+        nodes[source] = {"source": 0, "target": 1}
     else:
-    	nodes[source]["target"] = nodes[source]["target"] + 1
+        nodes[source]["target"] = nodes[source]["target"] + 1
     userlink = links[source]
     if target in userlink:
-    	userlink[target] = userlink[target] + 1;
+        userlink[target] = userlink[target] + 1;
     else:
-    	userlink[target] = 1;
+        userlink[target] = 1;
     if target in nodes:
-    	nodes[target]["source"] = nodes[target]["source"] + 1
+        nodes[target]["source"] = nodes[target]["source"] + 1
     else:
-    	nodes[target] = {"source": 1, "target": 0}
+        nodes[target] = {"source": 1, "target": 0}
 
 
 
 # nodes will end up as ["userA", "userB", ...]
 # links will end up as 
-#	{
-#		"userA": {"userB": 3, ...},
-#		"userB": {"userA": 1, ...},
-#		...
-#	}
-#	
+#    {
+#        "userA": {"userB": 3, ...},
+#        "userB": {"userA": 1, ...},
+#        ...
+#    }
+#    
 # Meaning that userA mentions userB 3 times, and userB mentions userA once.
 
 
 for line in fileinput.input(args):
     try:
-		tweet = json.loads(line)
-		user = tweet["user"]["screen_name"]
-		if opts.mode == 'mentions':
-			if "user_mentions" in tweet["entities"]:
-				for mention in tweet["entities"]["user_mentions"]:
-					addlink(user, str(mention["screen_name"]))
-		elif opts.mode == 'replies':
-			if not(tweet["in_reply_to_screen_name"] == None):
-				addlink(tweet["in_reply_to_screen_name"], user)
-		else: # default mode: retweets
-			if "retweeted_status" in tweet:
-				addlink(user, tweet["retweeted_status"]["user"]["screen_name"])
+        tweet = json.loads(line)
+        user = tweet["user"]["screen_name"]
+        if opts.mode == 'mentions':
+            if "user_mentions" in tweet["entities"]:
+                for mention in tweet["entities"]["user_mentions"]:
+                    addlink(user, str(mention["screen_name"]))
+        elif opts.mode == 'replies':
+            if not(tweet["in_reply_to_screen_name"] == None):
+                addlink(tweet["in_reply_to_screen_name"], user)
+        else: # default mode: retweets
+            if "retweeted_status" in tweet:
+                addlink(user, tweet["retweeted_status"]["user"]["screen_name"])
     except ValueError as e:
         sys.stderr.write("uhoh: %s\n" % e)
 
 json = d3json.nodeslinktrees(nodes, links, optsdict, argsdict)
 
 if opts.output == "json":
-	print json
+    print json
 else:
-	d3json.embed(opts.template, json)
+    d3json.embed(opts.template, json)

--- a/utils/directed.py
+++ b/utils/directed.py
@@ -15,6 +15,11 @@ opt_parser.add_option("-m", "--mode", dest="mode", help="retweets (default) | me
     default='retweets')
 opt_parser.add_option("-t", "--threshold", dest="threshold", type="int", 
 	help="minimum links to qualify for inclusion (default: 1)", default=1)
+opt_parser.add_option("-o", "--output", dest="output", type="str", 
+	help="embed | json (default: embed)", default="embed")
+opt_parser.add_option("-p", "--template", dest="template", type="str", 
+	help="name of template in utils/template (default: directed.html)", default="directed.html")
+	
 opts, args = opt_parser.parse_args()
 
 # prepare to serialize opts and args as json
@@ -76,4 +81,8 @@ for line in fileinput.input(args):
         sys.stderr.write("uhoh: %s\n" % e)
 
 json = d3json.nodeslinktrees(nodes, links, optsdict, argsdict)
-d3json.embed("directed.html", json)
+
+if opts.output == "json":
+	print json
+else:
+	d3json.embed(opts.template, json)

--- a/utils/templates/directed.html
+++ b/utils/templates/directed.html
@@ -28,6 +28,13 @@ div.sidebar_list {
 	float:left;
 }
 
+div#argsopts {
+	float: right;
+}
+div.metadata {
+	font-size: 75%;
+}
+
 path.link {
   fill: none;
   stroke: #666;
@@ -124,6 +131,7 @@ ul { margin: 0; padding: 0; list-style-type: none;}
 	var json = $JSON$;
 	
 	var mode = json["opts"]["mode"];
+	var threshold = json["opts"]["threshold"];
 	var links = json["links"];
 	var nodes = json["nodes"];
 	
@@ -159,11 +167,14 @@ ul { margin: 0; padding: 0; list-style-type: none;}
 	
 	function selecthtml(l) {
 		l = listsort(l);
-		html = "<select onchange='userselect(this.value)'>";
+		// show threshold
+		html = "<div id='filename' class='metadata'>" + json["args"][0] + "</div>"
+		html += "<div id='argsopts' class='metadata'>Threshold: " + threshold + "<br/>Mode: " + mode + "</div>";
+		html += "<select onchange='userselect(this.value)'>";
 		for (var a = 0; a < l.length; a++) {
 			html += "<option>" + l[a] + "</option>";
 		}
-		html += "</select>";	
+		html += "</select>";
 		return html;
 	}
 	

--- a/utils/templates/directed.html
+++ b/utils/templates/directed.html
@@ -121,14 +121,11 @@ ul { margin: 0; padding: 0; list-style-type: none;}
 
   
     <script type="text/javascript">
-
-	var mode = "$MODE$";
+	var json = $JSON$;
 	
-	var links = $LINKS$;
-
-	var nodes = $NODES$;
-	
-	
+	var mode = json["opts"]["mode"];
+	var links = json["links"];
+	var nodes = json["nodes"];
 	
 	function twitterlink(n) {
 		return "<a href='https://twitter.com/" + n + "'>" + n + "</n>";


### PR DESCRIPTION
Here's the first of the threatened PRs (in #41). The directed graph utility now uses a generic module to generate the D3-friendly json, and then optionally output it directly for reuse or embed it in the HTML template directed.html for immediate viewing. The new version is backwards-compatible, in that the default params produce the same output as the old version, but there are now options that can be set on the command line (via optparse). 

I hope that this provides a model for generating D3-friendly json in different formats, and I intend to build up d3json.py to do this. Next in line is a timeline bar chart.