### PR TITLE
Don't create geojson for [0,0] coordinates.

### DIFF
--- a/utils/geojson.py
+++ b/utils/geojson.py
@@ -7,7 +7,7 @@ features = []
 
 for line in fileinput.input():
     tweet = json.loads(line)
-    if tweet["geo"]:
+    if tweet["geo"] and any(tweet["geo"]["coordinates"]):
         features.append({
             "type": "Feature",
             "geometry": {


### PR DESCRIPTION
Quite a few tweets are returned with both coordinates 0, which is a highly unlikely spot to be tweeting from. Something like:
```json
"geo": {
    "type": "Point",
    "coordinates": [
      0,
      0
    ]
```
So I says, don't turn 'em into geojson.