### PR TITLE
Add --use flag to read query from text file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ each tweet to stdout as line oriented JSON. Twitter's search API only makes
 time is of the essence if you are trying to collect tweets for something 
 that has already happened. 
 
+You may also save the query in a text file, and load it using the --use flag:
+
+    twarc.py --use mysearch.txt > tweets.JSON
+
+Entering the --use flag without a file name will cause twarc to use "twarc-search.txt". 
+This flag is useful to keep a record of a complex query.
+
 ## Stream
 
 In stream mode twarc will listen to Twitter's [filter stream API](https://dev.twitter.com/streaming/reference/post/statuses/filter) for

--- a/twarc.py
+++ b/twarc.py
@@ -21,6 +21,9 @@ def main():
     parser = argparse.ArgumentParser("twarc")
     parser.add_argument("--search", dest="search", action="store",
                         help="search for tweets matching a query")
+    parser.add_argument("--use", dest="usesaved", action="store", nargs="?",
+                        help="use query in file (default twarc-search.txt)", 
+			const="twarc-search.txt")
     parser.add_argument("--max_id", dest="max_id", action="store",
                         help="maximum tweet id to search for")
     parser.add_argument("--since_id", dest="since_id", action="store",
@@ -41,6 +44,9 @@ def main():
 
     # figure out what tweets we will be iterating through
     t = Twarc()
+    if args.usesaved:
+        with open (args.usesaved, "r") as twarcsearch:
+            args.search=twarcsearch.read()
     if args.search:
         tweets = t.search(
             args.search, 
@@ -52,7 +58,7 @@ def main():
     elif args.hydrate:
         tweets = t.hydrate(open(args.hydrate))
     else:
-        raise argparse.ArgumentTypeError("must supply one of: --search --stream or --hydrate")
+        raise argparse.ArgumentTypeError("must supply one of: --search --use --stream or --hydrate")
 
     # iterate through the tweets and write them to stdout
     for tweet in tweets:


### PR DESCRIPTION
This allows you to keep your twarc query in a local text file, so that a given harvest might have a home directory in which the query and the harvested tweets live. The file makes it easier to manage more complex queries, and it makes the query available to twarc-report processes so that it can be automatically included in reports. 
It might also be useful to have a flag --save that would write a command-line query to twarc-search.txt. 
I've implemented it by overriding args.search with the string that is read from the file. I've tested with Cyrillic strings to be sure that Unicode is handled correctly.
I'm not sure how to handle archive.py so as to make it possible to use the --use flag without breaking its existing syntax. I'll have to read up on argparse options.