### PR TITLE
added unicodecsv to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytest
 python-dateutil
 requests_oauthlib
+unicodecsv


### PR DESCRIPTION
this module is required for utils/json2csv.py but wasn't listed yet.