### PR TITLE
Fix downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ twarc
 =====
 
 [![Build Status](https://secure.travis-ci.org/edsu/twarc.png)](http://travis-ci.org/edsu/twarc) 
+[![Downloads](https://img.shields.io/pypi/dm/twarc.svg)](http://pypi.org/twarc) 
 [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/edsu/twarc?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![DOI](https://zenodo.org/badge/12737/edsu/twarc.svg)](http://dx.doi.org/10.5281/zenodo.17385)
 


### PR DESCRIPTION
pypip.in has been down for a while, but http://shields.io/ is another service. 

This is the monthly badge; change `dm` to `dw` or `dd` for weekly or daily downloads.

[CI skip]