### PR TITLE
add optional lang param to search

### DIFF
--- a/twarc.py
+++ b/twarc.py
@@ -233,10 +233,10 @@ class Twarc(object):
         self.access_token_secret = access_token_secret
         self._connect()
 
-    def search(self, q, max_id=None, since_id=None):
+    def search(self, q, max_id=None, since_id=None, lang=None):
         """
-        Pass in a query with optional max_id and min_id and get back
-        an iterator for decoded tweets.
+        Pass in a query with optional max_id, min_id and lang and get
+        back an iterator for decoded tweets.
         """
         logging.info("starting search for %s", q)
         url = "https://api.twitter.com/1.1/search/tweets.json"
@@ -244,6 +244,8 @@ class Twarc(object):
             "count": 100,
             "q": q
         }
+        if lang is not None:
+            params['lang'] = lang
 
         while True:
             if since_id:


### PR DESCRIPTION
Twitter supports a few languages and has support for this in the API.

* https://dev.twitter.com/rest/reference/get/help/languages
* https://dev.twitter.com/rest/reference/get/search/tweets

> lang (optional): Restricts tweets to the given language,
  given by an ISO 639-1 code. Language detection is best-effort.

----

Alternative: Since [search](https://dev.twitter.com/rest/reference/get/search/tweets) supports even more optional parameters, it would maybe more general to write something like this:

    def search(self, q, max_id=None, since_id=None, **kwargs):
        ...
        params.update(kwargs)
        ...

Do you have any preferences?