### PR TITLE
Allow custom format time string for created_at in geojson

### DIFF
--- a/utils/geojson.py
+++ b/utils/geojson.py
@@ -10,7 +10,7 @@ from dateutil import tz
 
 opt_parser = optparse.OptionParser(usage="geojson.py [options] filename")
 opt_parser.add_option("-f", "--format-time", action="store_true", dest="format_time",
-		        help="Format 'created_at' time as Y-%m-%d %H:%M:%S. Or pass -c option with a custom format")
+		        help="Format 'created_at' time as Y-%m-%d %H:%M:%S. Additionally, you pass '-c' with a custom format")
 opt_parser.add_option("-c", "--custom-format", dest="custom_format",
 		        default='%Y-%m-%d %H:%M:%S', help="Custom format to use for'created_at' time")
 
@@ -53,6 +53,3 @@ for line in fileinput.input(sys.argv[-1]):
 
 geojson = {"type" : "FeatureCollection", "features": features}
 print(json.dumps(geojson, indent=2))
-
-
-

--- a/utils/geojson.py
+++ b/utils/geojson.py
@@ -1,14 +1,34 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
+import sys
 import json
 import fileinput
+import optparse
+import dateutil.parser
+from dateutil import tz
+
+opt_parser = optparse.OptionParser(usage="geojson.py [options] filename")
+opt_parser.add_option("-f", "--format-time", action="store_true", dest="format_time",
+		        help="Format 'created_at' time as Y-%m-%d %H:%M:%S. Or pass -c option with a custom format")
+opt_parser.add_option("-c", "--custom-format", dest="custom_format",
+		        default='%Y-%m-%d %H:%M:%S', help="Custom format to use for'created_at' time")
+
+opts, args = opt_parser.parse_args()
+
+def formatTime(time, custom_format):
+    to_zone = tz.tzlocal()
+    created_at = dateutil.parser.parse(time)
+    created_at = created_at.astimezone(to_zone)
+    return created_at.strftime(custom_format)
 
 features = []
 
-for line in fileinput.input():
+for line in fileinput.input(sys.argv[-1]):
     tweet = json.loads(line)
     if tweet["geo"] and any(tweet["geo"]["coordinates"]):
+	if opts.format_time:
+            tweet["created_at"] = formatTime(tweet["created_at"], opts.custom_format)
         features.append({
             "type": "Feature",
             "geometry": {
@@ -33,3 +53,6 @@ for line in fileinput.input():
 
 geojson = {"type" : "FeatureCollection", "features": features}
 print(json.dumps(geojson, indent=2))
+
+
+


### PR DESCRIPTION
Adds ability to create geojson with custom formatted "created_at" time string. I found it useful for pulling into various mapping applications.

If you run: 
`python geojson.py -f tweets.json` it will default to formatting the time with `%Y-%m-%d %H:%M:%S`

But, if you run:
`python geojson.py -f -c "&Y-%m-%d" tweets.json` it will use the custom format instead.
