### PR TITLE
Fix JS link

### DIFF
--- a/utils/wordcloud.py
+++ b/utils/wordcloud.py
@@ -54,7 +54,6 @@ print(("""<!DOCTYPE html>
 <meta charset="utf-8">
 <title>twarc wordcloud</title>
 <script src="http://d3js.org/d3.v3.min.js"></script>
-<script src="https://raw.githubusercontent.com/jasondavies/d3-cloud/master/build/d3.layout.cloud.js"></script>
 </head>
 <body>
 <script>

--- a/utils/wordcloud.py
+++ b/utils/wordcloud.py
@@ -54,7 +54,7 @@ print(("""<!DOCTYPE html>
 <meta charset="utf-8">
 <title>twarc wordcloud</title>
 <script src="http://d3js.org/d3.v3.min.js"></script>
-<script src="https://raw.github.com/jasondavies/d3-cloud/master/d3.layout.cloud.js"></script>
+<script src="https://raw.githubusercontent.com/jasondavies/d3-cloud/master/build/d3.layout.cloud.js"></script>
 </head>
 <body>
 <script>


### PR DESCRIPTION
Although the wordcloud is showing fine even though the old link is 404, that's because the JS is duplicated in this file.

Either the link or the JS code should be removed.