### PR TITLE
Add -v/--version flag to return the version number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ html
 custom
 img/
 *.ini
+.eggs

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup(
     author_email='ehs@pobox.com',
     py_modules=['twarc', ],
     scripts=['twarc.py', 'utils/twarc-archive.py'],
-    description='command line utility to archive Twitter search results as line-oriented-json',
+    description='command line utility to archive Twitter search results '
+                'as line-oriented-json',
     install_requires=dependencies,
     setup_requires=['pytest-runner'],
     tests_require=['pytest'],

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import sys
 
 from os.path import join
 from setuptools import setup
+from twarc import __version__
 
 
 if sys.version_info[0] < 3:
@@ -12,7 +13,7 @@ else:
 
 setup(
     name='twarc',
-    version='0.6.1',
+    version=__version__,
     url='http://github.com/edsu/twarc',
     author='Ed Summers',
     author_email='ehs@pobox.com',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import sys
 
 from os.path import join
 from setuptools import setup
-from twarc import __version__
+from version import __version__
 
 
 if sys.version_info[0] < 3:

--- a/twarc.py
+++ b/twarc.py
@@ -121,7 +121,7 @@ def main():
         )
     elif args.track or args.follow or args.locations:
         tweets = t.filter(track=args.track, follow=args.follow,
-                locations=args.locations)
+                          locations=args.locations)
     elif args.hydrate:
         tweets = t.hydrate(open(args.hydrate, 'rU'))
     else:
@@ -137,7 +137,8 @@ def main():
 
         # add some info to the log
         if "id_str" in tweet:
-            logging.info("archived https://twitter.com/%s/status/%s", tweet['user']['screen_name'], tweet["id_str"])
+            logging.info("archived https://twitter.com/%s/status/%s",
+                         tweet['user']['screen_name'], tweet["id_str"])
         elif 'limit' in tweet:
             logging.warn("%s tweets undelivered", tweet["limit"]["track"])
         elif 'warning' in tweet:
@@ -152,13 +153,15 @@ def load_config(filename, profile):
     config = configparser.ConfigParser()
     config.read(filename)
     data = {}
-    for key in ['access_token', 'access_token_secret', 'consumer_key', 'consumer_secret']:
+    for key in ['access_token', 'access_token_secret',
+                'consumer_key', 'consumer_secret']:
         try:
             data[key] = config.get(profile, key)
         except configparser.NoSectionError:
             sys.exit("no such profile %s in %s" % (profile, filename))
         except configparser.NoOptionError:
-            sys.exit("missing %s from profile %s in %s" % (key, profile, filename))
+            sys.exit("missing %s from profile %s in %s" % (
+                        key, profile, filename))
     return data
 
 
@@ -222,7 +225,8 @@ def rate_limit(f):
                     logging.warn("too many errors from Twitter, giving up")
                     resp.raise_for_status()
                 seconds = 60 * errors
-                logging.warn("%s from Twitter API, sleeping %s", resp.status_code, seconds)
+                logging.warn("%s from Twitter API, sleeping %s",
+                             resp.status_code, seconds)
                 time.sleep(seconds)
             else:
                 resp.raise_for_status()
@@ -239,6 +243,7 @@ def catch_conn_reset(f):
         ConnectionError = OpenSSL.SSL.SysCallError
     except:
         ConnectionError = requests.exceptions.ConnectionError
+
     def new_f(self, *args, **kwargs):
         try:
             return f(self, *args, **kwargs)

--- a/twarc.py
+++ b/twarc.py
@@ -25,8 +25,6 @@ else:
     # Python 3
     get_input = input
 
-__version__ = '0.6.1'
-
 
 def geo(value):
     return '-74,40,-73,41'

--- a/twarc.py
+++ b/twarc.py
@@ -24,6 +24,8 @@ else:
     # Python 3
     get_input = input
 
+__version__ = '0.6.1'
+
 
 def geo(value):
     return '-74,40,-73,41'
@@ -34,6 +36,9 @@ def main():
     The twarc command line.
     """
     parser = argparse.ArgumentParser("twarc")
+    parser.add_argument('-v', '--version', action='version',
+                        version='%(prog)s {version}'.format(
+                            version=__version__))
     parser.add_argument("--search", dest="search",
                         help="search for tweets matching a query")
     parser.add_argument("--max_id", dest="max_id",
@@ -68,7 +73,7 @@ def main():
                         help="Config file containing Twitter keys and secrets")
     parser.add_argument('-p', '--profile', default='main',
                         help="Name of a profile in your configuration file")
-    parser.add_argument('-w', '--warnings', action='store_true', 
+    parser.add_argument('-w', '--warnings', action='store_true',
                         help="Include warning messages in output")
 
     args = parser.parse_args()
@@ -125,7 +130,7 @@ def main():
 
     # iterate through the tweets and write them to stdout
     for tweet in tweets:
-        
+
         # include warnings in output only if they asked for it
         if 'id_str' in tweet or args.warnings:
             print(json.dumps(tweet))
@@ -417,7 +422,7 @@ class Twarc(object):
 
     def connect(self):
         """
-        Sets up the HTTP session to talk to Twitter. If one is active it is 
+        Sets up the HTTP session to talk to Twitter. If one is active it is
         closed and another one is opened.
         """
         if self.client:

--- a/twarc.py
+++ b/twarc.py
@@ -11,6 +11,7 @@ import argparse
 import requests
 
 from requests_oauthlib import OAuth1Session
+from version import __version__
 
 try:
     import configparser  # Python 3

--- a/version.py
+++ b/version.py
@@ -1,0 +1,4 @@
+__version__ = '0.6.1'
+
+# End of file
+


### PR DESCRIPTION
Fixes #99.

```bash
$ twarc.py --version
twarc 0.6.1
$ twarc.py -v
twarc 0.6.1
```

Put the version number in version.py and import that into setup.py and twarc.py.

It can't be put in twarc.py and imported into setup.py, because at that time the requests module (imported by twarc.py) may not have been installed yet by setup.py.

See http://stackoverflow.com/a/24517154/724176