### PR TITLE
Add --geocode option for location-based searches

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ each tweet to stdout as line oriented JSON. Twitter's search API only makes
 time is of the essence if you are trying to collect tweets for something
 that has already happened.
 
+### Search for tweets within a given area
+
+You can specify a search term or omit one to search for all tweets within a given radius of a given latitude/longitude:
+
+    twarc.py --search ferguson --geocode 38.7442,-90.3054,1mi
+    twarc.py --geocode 38.7442,-90.3054,1mi
+    
+See the [API documentation](https://dev.twitter.com/rest/reference/get/search/tweets#api-param-search_geocode) for more details on how these searches work.
+
 ## Filter Stream
 
 In filter stream mode twarc will listen to Twitter's [filter stream API](https://dev.twitter.com/streaming/reference/post/statuses/filter) for
@@ -247,6 +256,16 @@ Optionally you can export GeoJSON with centroids replacing bounding boxes:
 And if you do export GeoJSON with centroids, you can add some random fuzzing:
 
     % utils/geojson.py tweets.json --centroid --fuzz 0.01 > tweets.geojson
+
+To filter tweets by presence or absence of geo coordinates (or Place, see [API documentation](https://dev.twitter.com/overview/api/places)):
+
+    % utils/geofilter.py tweets.json --yes-coordinates > tweets-with-geocoords.json
+    % cat tweets.json | utils/geofilter.py --no-place > tweets-with-no-place.json
+    
+To filter tweets by a GeoJSON fence (requires [Shapely](https://github.com/Toblerity/Shapely)):
+
+    % utils/geofilter.py tweets.json --fence limits.geojson > fenced-tweets.json
+    % cat tweets.json | utils/geofilter.py --fence limits.geojson > fenced-tweets.json
 
 If you suspect you have duplicate in your tweets you can dedupe them:
 

--- a/test_twarc.py
+++ b/test_twarc.py
@@ -92,6 +92,23 @@ def test_paging():
     assert count == 500
 
 
+def test_geocode():
+    # look for tweets from New York ; the search radius is larger than NYC
+    # so hopefully we'll find one from New York in the first 100?
+    count = 0
+    found = False
+
+    for tweet in t.search(None, geocode='40.7484,-73.9857,1mi'):
+        if (tweet['place'] or {}).get('name') == 'Manhattan':
+            found = True
+            break
+        if count > 100:
+            break
+        count += 1
+
+    assert found
+
+
 def test_track():
     tweet = next(t.filter(track="obama"))
     json_str = json.dumps(tweet)

--- a/twarc.py
+++ b/twarc.py
@@ -52,6 +52,8 @@ def main():
                         default="recent", help="search result type")
     parser.add_argument("--lang", dest="lang",
                         help="limit to ISO 639-1 language code"),
+    parser.add_argument("--geocode", dest="geocode",
+                        help="limit by latitude,longitude,radius")
     parser.add_argument("--track", dest="track",
                         help="stream tweets matching track filter")
     parser.add_argument("--follow", dest="follow",
@@ -128,13 +130,14 @@ def main():
     users = []
 
     # Calls that return tweets
-    if args.search:
+    if args.search or args.geocode:
         tweets = t.search(
             args.search,
             since_id=args.since_id,
             max_id=args.max_id,
             lang=args.lang,
             result_type=args.result_type,
+            geocode=args.geocode
         )
     elif args.track or args.follow or args.locations:
         tweets = t.filter(track=args.track, follow=args.follow,
@@ -319,7 +322,7 @@ def catch_timeout(f):
 
 def catch_gzip_errors(f):
     """
-    A decorator to handle gzip encoding errors which have been known to 
+    A decorator to handle gzip encoding errors which have been known to
     happen during hydration.
     """
     def new_f(self, *args, **kwargs):
@@ -361,10 +364,10 @@ class Twarc(object):
         self.connect()
 
     def search(self, q, max_id=None, since_id=None, lang=None,
-               result_type='recent'):
+               result_type='recent', geocode=None):
         """
-        Pass in a query with optional max_id, min_id or lang and get
-        back an iterator for decoded tweets. Defaults to recent (i.e.
+        Pass in a query with optional max_id, min_id, lang or geocode
+        and get back an iterator for decoded tweets. Defaults to recent (i.e.
         not mixed, the API default, or popular) tweets.
         """
         logging.info("starting search for %s", q)
@@ -379,6 +382,8 @@ class Twarc(object):
             params['result_type'] = result_type
         else:
             params['result_type'] = 'recent'
+        if geocode is not None:
+            params['geocode'] = geocode
 
         while True:
             if since_id:

--- a/utils/geofilter.py
+++ b/utils/geofilter.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import argparse
+import json
+import sys
+
+from shapely.geometry import shape
+
+
+def process(line, has_coordinates=None, has_place=None, fence=None):
+    tweet = json.loads(line)
+
+    coordinates = tweet.get('coordinates')
+    place = tweet.get('place')
+
+    if any([
+        has_coordinates and not coordinates,
+        has_coordinates is False and coordinates,
+        has_place and not place,
+        has_place is False and place,
+    ]):
+        return
+
+    if fence and (coordinates or place):
+        if coordinates:
+            location = shape(coordinates)
+        else:
+            location = shape(place['bounding_box'])
+
+        if not fence.contains(location):
+            return
+
+    print(line.strip('\n'))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('infile', nargs='?', type=argparse.FileType('r'),
+                        default=sys.stdin)
+    parser.add_argument('--yes-coordinates', dest='has_coordinates',
+                        action='store_true')
+    parser.add_argument('--no-coordinates', dest='has_coordinates',
+                        action='store_false')
+    parser.add_argument('--yes-place', dest='has_place', action='store_true')
+    parser.add_argument('--no-place', dest='has_place', action='store_false')
+    parser.add_argument('--fence', default=None,
+                        help='geojson file with geofence')
+    parser.set_defaults(has_coordinates=None, has_place=None)
+    args = parser.parse_args()
+
+    fence = None
+    if args.fence:
+        with open(args.fence, 'r') as f:
+            fence = shape(json.loads(f.read()))
+
+    for line in args.infile:
+        process(line, args.has_coordinates, args.has_place, fence)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR adds a `--geocode` command line option that maps to the [geocode](https://dev.twitter.com/rest/reference/get/search/tweets#api-param-search_geocode) search API option. It supports location-based searches with or without a query parameter.

It also adds a new `utils/geofilter.py` utility to allow for filtering of tweets by presence/absence of geo data, as well as filtering by arbitrary GeoJSON shape (e.g. a polygon).

`README.md` has been updated and all code has been tested with both Python 2.7 and Python 3.5.

**New `--geocode` command line option**

The search API `geocode`parameter lets you retrieve tweets from within a given radius (in miles or kilometers) from a given location, specified as latitude and longitude (in degrees). For example:

```sh
twarc.py --search ferguson --geocode 38.7442,-90.3054,1mi
```

You can also omit the search term if you want to retrieve all available tweets from the area:

```sh
twarc.py --geocode 38.7442,-90.3054,1km
````

I added a new test as `test_twarc.test_geocode` reusing the logic from `test_twarc.test_locations`.

**New `utils/geofilter.py` utility**

Using the `geocode` search parameter can pull back tweets with different kinds of geo data: the specific lat/lng coordinates it was sent from, a [Place](https://dev.twitter.com/overview/api/places) it was associated with (although potentially not sent from), or neither of these, returned only because the user's profile location is a match.

A new `utils/geofilter.py` utility lets you filter a file of JSON tweets by presence/absence of both coordinate and Place data. Note that you can both pass the filename in as a command line parameter or pipe a stream via stdin:

```sh
utils/geofilter.py tweets.json --yes-coordinates > tweets-with-geocoords.json
cat tweets.json | utils/geofilter.py --no-place > tweets-with-no-place.json
```

This utility also lets you optionally filter tweets by a more complex geofence (using an additional [Shapely](https://github.com/Toblerity/Shapely) requirement). For example, consider the use case where you want to find tweets from a certain neighborhood for which you have a GeoJSON outline (as a Polygon). Using this new utility, you could do an initial search for your keyword of interest to collect all tweets and then filter them using:

```sh
utils/geofilter.py all-tweets.json --fence limits.geojson > fenced-tweets.json
```

This is also useful when used in combination with the new `--geocode` option, e.g. first finding tweets near some point and then filtering that circular search area down to something more specific.