### PR TITLE
adds limits to retrying on connection error and http errors.

### DIFF
--- a/requirements/python2.txt
+++ b/requirements/python2.txt
@@ -2,3 +2,4 @@ pytest
 python-dateutil
 requests_oauthlib
 unicodecsv
+mock

--- a/test_twarc.py
+++ b/test_twarc.py
@@ -3,6 +3,14 @@ import re
 import json
 import time
 import logging
+import pytest
+try:
+    from unittest.mock import patch, call, MagicMock  # Python 3
+except ImportError:
+    from mock import patch, call, MagicMock  # Python 2
+
+from requests_oauthlib import OAuth1Session
+import requests
 
 import twarc
 
@@ -286,3 +294,43 @@ def test_hydrate():
         assert tweet['id_str']
         count += 1
     assert count > 100  # may need to adjust as these might get deleted
+
+
+@patch("twarc.OAuth1Session", autospec=True)
+def test_connection_error_get(oauth1session_class):
+    mock_oauth1session = MagicMock(spec=OAuth1Session)
+    oauth1session_class.return_value = mock_oauth1session
+    mock_oauth1session.get.side_effect = requests.exceptions.ConnectionError
+    t = twarc.Twarc("consumer_key", "consumer_secret", "access_token", "access_token_secret", connection_errors=3)
+    with pytest.raises(requests.exceptions.ConnectionError):
+        t.get("https://api.twitter.com")
+
+    assert 3 == mock_oauth1session.get.call_count
+
+
+@patch("twarc.OAuth1Session", autospec=True)
+def test_connection_error_post(oauth1session_class):
+    mock_oauth1session = MagicMock(spec=OAuth1Session)
+    oauth1session_class.return_value = mock_oauth1session
+    mock_oauth1session.post.side_effect = requests.exceptions.ConnectionError
+    t = twarc.Twarc("consumer_key", "consumer_secret", "access_token", "access_token_secret", connection_errors=2)
+    with pytest.raises(requests.exceptions.ConnectionError):
+        t.post("https://api.twitter.com")
+
+    assert 2 == mock_oauth1session.post.call_count
+
+
+def test_http_error_sample():
+    t = twarc.Twarc("consumer_key", "consumer_secret", "access_token", "access_token_secret", http_errors=2)
+    with pytest.raises(requests.exceptions.HTTPError):
+        t.sample().next()
+
+def test_http_error_filter():
+    t = twarc.Twarc("consumer_key", "consumer_secret", "access_token", "access_token_secret", http_errors=3)
+    with pytest.raises(requests.exceptions.HTTPError):
+        t.filter(track="test").next()
+
+def test_http_error_timeline():
+    t = twarc.Twarc("consumer_key", "consumer_secret", "access_token", "access_token_secret", http_errors=4)
+    with pytest.raises(requests.exceptions.HTTPError):
+        t.timeline(user_id="test").next()


### PR DESCRIPTION
In our (heavy) use of twarc for Social Feed Manager we've encountered a number of situations where twarc retries infinitely against network/connection problems.  This PR adds the ability to provide limits on the number of retries for connection errors and http errors.

Here's some of the infinite errors that we've found in our logs:
```
2016-09-04 01:01:59,904: requests.packages.urllib3.connectionpool --> Starting new HTTPS connection (1): stream.twitter.com
2016-09-04 01:02:09,917: root --> caught connection error HTTPSConnectionPool(host='stream.twitter.com', port=443): Max retries exceeded with url: /1.1/statuses/filter.json (Cause
d by ProxyError('Cannot connect to proxy.', error('Tunnel connection failed: 500 [Errno -2] Name or service not known',)))
2016-09-04 01:02:09,917: root --> closing existing http session
2016-09-04 01:02:09,917: root --> closing last response
```

```
2016-09-11 08:43:49,494: root --> creating http session
2016-09-11 08:43:49,497: requests.packages.urllib3.connectionpool --> Starting new HTTPS connection (1): stream.twitter.com
2016-09-11 08:43:49,543: root --> caught connection error ("bad handshake: Error([('rsa routines', 'RSA_padding_check_PKCS1_type_1', 'block type is not 01'), ('rsa routines', 'RSA_EAY_PUBLIC_DECRYPT', 'padding check failed'), ('asn1 encoding routines', 'ASN1_item_verify', 'EVP lib'), ('SSL routines', 'SSL3_GET_SERVER_CERTIFICATE', 'certificate verify failed')],)",)
2016-09-11 08:43:49,543: root --> closing existing http session
```

```
2016-09-15 14:47:31,386: root --> 401 Client Error: Authorization Required for url: https://stream.twitter.com/1.1/statuses/sample.json
2016-09-15 14:47:31,386: root --> sleeping 5
2016-09-15 14:47:36,395: root --> connecting to sample stream
2016-09-15 14:47:36,399: requests.packages.urllib3.connectionpool --> Starting new HTTPS connection (2): stream.twitter.com
```

