### PR TITLE
Follower and friend id lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ target/
 # CloneDigger
 output.html
 
+# pyenv
+.python-version
+
 config.py
 *.json
 *.html
@@ -66,3 +69,4 @@ custom
 img/
 *.ini
 .eggs
+*.swp

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 twarc
 =====
 
-[![Build Status](https://secure.travis-ci.org/edsu/twarc.png)](http://travis-ci.org/edsu/twarc) 
+[![Build Status](https://secure.travis-ci.org/edsu/twarc.png)](http://travis-ci.org/edsu/twarc)
 [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/edsu/twarc?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![DOI](https://zenodo.org/badge/12737/edsu/twarc.svg)](http://dx.doi.org/10.5281/zenodo.17385)
 
 twarc is a command line tool and Python library for archiving Twitter JSON
-data. Each tweet is represented as a JSON object that is exactly what was 
-returned from the Twitter API. Tweets are stored as line-oriented JSON. Twarc runs in three modes: search, filter stream and hydrate. When running in 
-each mode twarc will stop and resume activity in order to work within the 
+data. Each tweet is represented as a JSON object that is exactly what was
+returned from the Twitter API. Tweets are stored as line-oriented JSON. Twarc runs in three modes: search, filter stream and hydrate. When running in
+each mode twarc will stop and resume activity in order to work within the
 Twitter API's [rate limits](https://dev.twitter.com/rest/public/rate-limiting).
 
 ## Install
@@ -22,19 +22,19 @@ Before using twarc you will need to register an application at
 [apps.twitter.com](http://apps.twitter.com). Once you've created your
 application, note down the consumer key, consumer secret and then click to
 generate an access token and access token secret. With these four variables
-in hand you are ready to start using twarc. 
+in hand you are ready to start using twarc.
 
-The first time you run twarc it will prompt you for these keys and store them 
+The first time you run twarc it will prompt you for these keys and store them
 in a `.twarc` file in your home directory. Sometimes it can be handy to store
 multiple authorization keys for different Twitter accounts in your config
-file.  So if you can have multiple profiles to your `.twarc` file, for 
+file.  So if you can have multiple profiles to your `.twarc` file, for
 example:
 
     [main]
     consumer_key=lksdfljklksdjf
     consumer_secret=lkjsdflkjsdlkfj
     access_token=lkslksjksljk3039jklj
-    access_token_secret=lksdjfljsdkjfsdlkfj 
+    access_token_secret=lksdjfljsdkjfsdlkfj
 
     [another]
     consumer_key=lkjsdflsj
@@ -46,7 +46,7 @@ You then use the other profile with the `--profile` option:
 
     twarc.py --profile another --search ferguson
 
-twarc will also look for authentication keys in the environment if you 
+twarc will also look for authentication keys in the environment if you
 would prefer to set them there using the following names:
 
 * CONSUMER\_KEY
@@ -85,8 +85,8 @@ See the [API documentation](https://dev.twitter.com/rest/reference/get/search/tw
 
 In filter stream mode twarc will listen to Twitter's [filter stream API](https://dev.twitter.com/streaming/reference/post/statuses/filter) for
 tweets that match a particular filter. You can filter by keywords using
-`--track`, user identifiers using `--follow` and places using `--locations`. 
-Similar to search mode twarc will write these tweets to stdout as line 
+`--track`, user identifiers using `--follow` and places using `--locations`.
+Similar to search mode twarc will write these tweets to stdout as line
 oriented JSON:
 
 ### Stream tweets containing a keyword
@@ -95,7 +95,7 @@ oriented JSON:
 
 ### Stream tweets from/to users
 
-Note: you must use the user identifiers, for example these are the 
+Note: you must use the user identifiers, for example these are the
 user ids for the @guardian and @nytimes:
 
     twarc.py --follow "87818409,807095" > tweets.json
@@ -129,8 +129,8 @@ fetch the full JSON for each tweet and write it to stdout as line-oriented JSON:
 
 ## Sample Stream
 
-In sample stream mode twarc will listen to Twitter's 
-[sample stream API](https://dev.twitter.com/streaming/reference/get/statuses/sample) 
+In sample stream mode twarc will listen to Twitter's
+[sample stream API](https://dev.twitter.com/streaming/reference/get/statuses/sample)
 for a random sample of recent public statuses. Similar to search mode and filter stream
 mode, twarc will write these tweets to stdout as line oriented JSON:
 
@@ -138,7 +138,7 @@ mode, twarc will write these tweets to stdout as line oriented JSON:
 
 ## User Timeline
 
-In user timeline mode twarc will use Twitter's 
+In user timeline mode twarc will use Twitter's
 [user timeline API](https://dev.twitter.com/rest/reference/get/statuses/user_timeline)
 to collect the most recent tweets posted by the user indicated by screen_name:
 
@@ -150,9 +150,9 @@ or by user_id:
 
 ## User Lookup
 
-In user lookup mode twarc will use Twitter's 
+In user lookup mode twarc will use Twitter's
 [user lookup API](https://dev.twitter.com/rest/reference/get/users/lookup)
-to collect fully hydrated [user objects](https://dev.twitter.com/overview/api/users) 
+to collect fully hydrated [user objects](https://dev.twitter.com/overview/api/users)
 for up to 100 users per request as specified by a list of one or more user screen names:
 
 	twarc.py --lookup_screen_names screen_names > users.json
@@ -161,9 +161,24 @@ or user_ids:
 
 	twarc.py --lookup_user_ids user_ids > users.json
 
+
+## Follower Ids
+
+In follower id mode twarc will use Twitter's
+[follower id API](https://dev.twitter.com/rest/reference/get/followers/ids)
+to collect the most recent 5000 user ids for exactly one user screen name
+per request as specified as an argument:
+
+        twarc.py --follower_ids screen_name > follower_ids.txt
+
+This can work in concert with user lookup mode, where you can invoke
+the resulting follower id list as `--lookup_user_ids`:
+
+        twarc.py --lookup_user_ids `cat follower_ids.txt` > followers.json
+
 ## Archive
 
-In addition to `twarc.py` when you install twarc you will also get the 
+In addition to `twarc.py` when you install twarc you will also get the
 `twarc-archive.py` command line tool. This uses twarc as a library to
 periodically collect data matching a particular search query. It's useful if you
 don't necessarily want to collect tweets as they happen with the streaming
@@ -177,7 +192,7 @@ no duplicates.
 For example this will collect all the tweets mentioning the word "ferguson" from
 the search API and write them to a unique file in `/mnt/tweets/ferguson`.
 
-    twarc-archive.py ferguson /mnt/tweets/ferguson 
+    twarc-archive.py ferguson /mnt/tweets/ferguson
 
 ## Use as a Library
 

--- a/README.md
+++ b/README.md
@@ -166,15 +166,31 @@ or user_ids:
 
 In follower id mode twarc will use Twitter's
 [follower id API](https://dev.twitter.com/rest/reference/get/followers/ids)
-to collect the most recent 5000 user ids for exactly one user screen name
-per request as specified as an argument:
+to collect the most recent 5000 follower user ids for exactly one user screen
+name per request as specified as an argument:
 
         twarc.py --follower_ids screen_name > follower_ids.txt
+
+The result will include exactly one user id per line for at most 5000 followers
+for the screen name.  The response order is reverse chronological, or most recent
+followers first.
 
 This can work in concert with user lookup mode, where you can invoke
 the resulting follower id list as `--lookup_user_ids`:
 
         twarc.py --lookup_user_ids `cat follower_ids.txt` > followers.json
+
+## Friend ids
+
+Like follower id mode, in friend id mode twars will use Twitter's
+[friend id API](https://dev.twitter.com/rest/reference/get/friends/ids)
+to collect the most recent 5000 friend user ids for exactly one user screen
+name per request as specified as an argument:
+
+    twarc.py --friend_ids screen_name > friend_ids.txt
+
+Also like in follower id mode, the results will be reverse chronological, and
+they can be fed to --lookup_user_ids in the same way demonstrated above.
 
 ## Archive
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ the resulting follower id list as `--lookup_user_ids`:
 
 ## Friend ids
 
-Like follower id mode, in friend id mode twars will use Twitter's
+Like follower id mode, in friend id mode twarc will use Twitter's
 [friend id API](https://dev.twitter.com/rest/reference/get/friends/ids)
 to collect the most recent 5000 friend user ids for exactly one user screen
 name per request as specified as an argument:

--- a/twarc.py
+++ b/twarc.py
@@ -516,7 +516,7 @@ class Twarc(object):
         """
         screen_name = screen_name.lstrip('@')
         url = 'https://api.twitter.com/1.1/followers/ids.json'
-        params = {screen_name: screen_name}
+        params = {'screen_name': screen_name}
         try:
             resp = self.get(url, params=params, allow_404=True)
         except requests.exceptions.HTTPError as e:
@@ -534,7 +534,7 @@ class Twarc(object):
         """
         screen_name = screen_name.lstrip('@')
         url = 'https://api.twitter.com/1.1/friends/ids.json'
-        params = {screen_name: screen_name}
+        params = {'screen_name': screen_name}
         try:
             resp = self.get(url, params=params, allow_404=True)
         except requests.exceptions.HTTPError as e:


### PR DESCRIPTION
Adds two new modes for fetching follower and friend id lists.  No cursoring yet; the standard API call will return up to 5000 ids by default, which is enough for many common use cases.

Unfortunately my editor is aggressive about trailing whitespace, which explains all the changes in the README file.  I only intended to added sections corresponding to the two new modes.  If you want a PR without those, I'll update.  Kinda harmless though, so maybe it's not a problem.

The two new methods on `Twarc`, `follower_ids` and `friend_ids`, are kinda repetitive.  Could be de-DRY'd if it mattered.