### PR TITLE
adding trend functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ img/
 *.ini
 .eggs
 *.swp
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -191,6 +191,60 @@ specified as an argument:
 Also like in follower id mode, the results will be reverse chronological, and
 they can be fed to --lookup_user_ids in the same way demonstrated above.
 
+## Trend modes
+
+Twitter's API offers three calls for fetching information about trends.  All
+three return JSON data, but each has its own focus.  To keep things simple, twarc
+returns the JSON data straight from the API, but with one result per line, unless
+specified otherwise.  Details about each call follow.
+
+### Trends available
+
+As of October 2016, Twitter gathers trend information for 467 distinct regions,
+including "Worldwide", 62 countries, 402 towns, and two areas that don't neatly
+fit into these categories, Ahsa and Soweto.  In trends available mode, twarc
+returns the entire list of all of these regions from the
+[trends available API](https://dev.twitter.com/rest/reference/get/trends/available):
+
+        twarc.py --trends_available
+
+Each region will be written to stdout, one JSON record per line.
+
+### Trends place
+
+The [trends place API](https://dev.twitter.com/rest/reference/get/trends/place)
+returns a list of all trends for a particular region (one of the regions listed)
+in the results for `--trends_available`).  It also includes three extra values,
+`as_of` and `created_at`, which are both
+[W3C Date Time](https://www.w3.org/TR/NOTE-datetime) compatible timestamps, and
+a list of regions for which trends are provided in the results, including a
+region name and [WOE id](http://developer.yahoo.com/geo/geoplanet/) for each.
+The API call only accepts one id at a time, though, and the dates do not provide
+terribly much information, so twarc's response simplifies the result to just the
+list of applicable trends.
+
+        twarc.py --trends_place WOEID
+
+Each trend will be written to stdout, one JSON record per line.
+
+A variation on this call will exclude hashtags from trend lists:
+
+        twarc.py --trends_place_exclude WOEID
+
+The result format is the same, it will simply exclude hashtags.  This is a
+feature of the Twitter API call, not post-processing in twarc.
+
+### Trends closest
+
+The
+[trends closest API](https://dev.twitter.com/rest/reference/get/trends/closest)
+returns a list of regions bounded a specific latitude and longitude.  This API
+call only accepts one lat, lon pair per call.
+
+        twarc.py --trends_closest 39.9062,-79.4679
+
+The result format is the same as for trends available.
+
 ## Archive
 
 In addition to `twarc.py` when you install twarc you will also get the

--- a/test_twarc.py
+++ b/test_twarc.py
@@ -201,6 +201,32 @@ def test_timeline_by_screen_name():
         assert tweet['user']['screen_name'].lower() == screen_name.lower()
 
 
+def test_trends_available():
+    # fetches all available trend regions and checks presence of likely member
+    trends = t.trends_available()
+    worldwide = [t for t in trends if t['placeType']['name'] == 'Supername']
+    assert worldwide[0]['name'] == 'Worldwide'
+
+
+def test_trends_place():
+    # fetches recent trends for Amsterdam, WOEID 727232
+    trends = t.trends_place(727232)
+    assert len(list(trends)) > 0
+
+
+def test_trends_closest():
+    # fetches regions bounding the specified lat and lon
+    trends = t.trends_closest(38.883137, -76.990228)
+    assert len(list(trends)) > 0
+
+
+def test_trends_place_exclude():
+    # fetches recent trends for Amsterdam, WOEID 727232, sans hashtags
+    trends = t.trends_place(727232, exclude='hashtags')
+    hashtag_trends = [t for t in trends if t['name'].startswith('#')]
+    assert len(hashtag_trends) == 0
+
+
 def test_follower_ids():
     # you can only get 5000 at a time, so this will test the cursor
     count = 0


### PR DESCRIPTION
Adds support for all of Twitter's trend-related API calls.  Includes tests.

The only thing that doesn't feel quite 100% right is the handling of the LAT,LONG argument for `--trends_closest`.  It requires a "LAT,LONG" string of two floats with no spaces.  It might be better to be a little more flexible about that, handling the input cases with spaces or no comma the right way, but the right argparse approach to that isn't readily apparent to me just yet.